### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   chromatic:
     name: Run Chromatic
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/coingaming/moon-ui/security/code-scanning/1](https://github.com/coingaming/moon-ui/security/code-scanning/1)

To fix this issue, add an explicit `permissions` block to the job definition for `chromatic` within `.github/workflows/chromatic.yml`. Set `contents: read`, which grants the minimum required permission for reading repository contents and running the workflow steps shown. This block should be added directly under the job name (`name: Run Chromatic`) for clarity and specificity. No further code or dependency changes are necessary, and no other permissions (write or access to issues, pull-requests, etc.) are required for the shown steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
