### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,6 @@
 name: Release new docs
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/coingaming/moon-ui/security/code-scanning/2](https://github.com/coingaming/moon-ui/security/code-scanning/2)

To fix this problem, you should add a `permissions` key at the root of the workflow YAML file (just under the `name`), so it applies globally to all jobs unless overridden. For most build-and-push workflows, only `contents: read` is required (to checkout and read repository files); unless a job needs to modify repository contents with GITHUB_TOKEN, anything more permissive is not required. In this specific workflow, the only action performing a git push is using a custom token (`MOON_GH_TOKEN`), not GITHUB_TOKEN, so both jobs can function with simple read-only permissions on the GITHUB_TOKEN.

You should add:
```yaml
permissions:
  contents: read
```
immediately below the `name:` line at the top of the file.

No further code or methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
